### PR TITLE
fix memory estimation for quantized models

### DIFF
--- a/hw2_kws/README.md
+++ b/hw2_kws/README.md
@@ -107,10 +107,18 @@ profile(Model(), (torch.randn(1, 1, 4), ))  # -> (6.0 MACs, 3.0 parameters)
 
 ### Memory estimation
 ```python
-def get_size_in_megabytes(model):
-    num_params = sum([p.numel() for p in model.parameters() if p.requires_grad])
-    param_size = next(model.parameters()).element_size()
-    return (num_params * param_size) / (2 ** 20)
+import os
+
+def get_size_in_megabytes(model): # https://pytorch.org/tutorials/recipes/recipes/dynamic_quantization.html#look-at-model-size
+    torch.save(model.state_dict(), "temp.p")
+    size=os.path.getsize("temp.p") / 2**20
+    os.remove('temp.p')
+    return size
+
+# compare the sizes
+f=print_size_of_model(float_lstm,"fp32")
+q=print_size_of_model(quantized_lstm,"int8")
+print("{0:.2f} times smaller".format(f/q))
 ```
    
 

--- a/hw2_kws/README.md
+++ b/hw2_kws/README.md
@@ -114,11 +114,6 @@ def get_size_in_megabytes(model): # https://pytorch.org/tutorials/recipes/recipe
     size=os.path.getsize("temp.p") / 2**20
     os.remove('temp.p')
     return size
-
-# compare the sizes
-f=print_size_of_model(float_lstm,"fp32")
-q=print_size_of_model(quantized_lstm,"int8")
-print("{0:.2f} times smaller".format(f/q))
 ```
    
 


### PR DESCRIPTION
master:
```python
def get_size_in_megabytes(model):
    num_params = sum([p.numel() for p in model.parameters() if p.requires_grad])
    param_size = next(model.parameters()).element_size()
    return (num_params * param_size) / (2 ** 20)

get_size_in_megabytes(model) / get_size_in_megabytes(model_int8) # 87.1819306930693 times is too much for reducing size from 32 bytes to 8 bytes
```
fixed:
```python
import os

def get_size_in_megabytes(model): # https://pytorch.org/tutorials/recipes/recipes/dynamic_quantization.html#look-at-model-size
    torch.save(model.state_dict(), "temp.p")
    size=os.path.getsize("temp.p") / 2**20
    os.remove('temp.p')
    return size

get_size_in_megabytes(model) / get_size_in_megabytes(model_int8) # 3.123530489316078 is logical, because not all layers has been quantized
```